### PR TITLE
Download voters identifiers

### DIFF
--- a/app/controllers/decidim/votings/admin/votes_controller.rb
+++ b/app/controllers/decidim/votings/admin/votes_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    module Admin
+      class VotesController < Decidim::Votings::Admin::ApplicationController
+        def index
+          @votes = voting.vote_class.for_voting(voting)
+          @votes = @votes.by_simulation_code(voting.simulation_code) unless voting.started?
+          render "index", layout: false, formats: [:text]
+        end
+
+        private
+
+        def voting
+          @voting ||= Voting.find(params[:voting_id])
+        end
+      end
+    end
+  end
+end

--- a/app/models/decidim/votings/simulated_vote.rb
+++ b/app/models/decidim/votings/simulated_vote.rb
@@ -3,6 +3,9 @@
 module Decidim
   module Votings
     class SimulatedVote < Decidim::Votings::Vote
+      self.table_name = "decidim_votings_simulated_votes"
+
+      scope :by_simulation_code, ->(simulation_code) { where(simulation_code: simulation_code) }
     end
   end
 end

--- a/app/views/decidim/votings/admin/votes/index.text.erb
+++ b/app/views/decidim/votings/admin/votes/index.text.erb
@@ -1,0 +1,3 @@
+<% @votes.find_each do |vote| %>
+<%= vote.voter_identifier %>
+<% end %>

--- a/app/views/decidim/votings/admin/votings/index.html.erb
+++ b/app/views/decidim/votings/admin/votings/index.html.erb
@@ -46,6 +46,12 @@
                                      class: 'action-icon--remove',
                                      data: { confirm: t('actions.confirm_destroy', scope: 'decidim.votings') } %>
                 <% end %>
+                <%= icon_link_to 'data-transfer-download',
+                                 voting_votes_path(voting, format: 'txt'),
+                                 t('actions.voters', scope: 'decidim.votings'),
+                                 method: :get,
+                                 class: 'action-icon--download' %>
+
               </td>
             </tr>
         <% end %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -42,6 +42,7 @@ es:
         edit: Editar
         destroy: Esborrar
         confirm_destroy: ¿Estàs segur?
+        voters: descarregar identificadors de votants
       messages:
         census_limit: Tu usuario no tiene la antigüedad requerida para participar en esta votación.
         finished: Ha llegado la fecha límite para votar. La votación está cerrada.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,7 @@ en:
         edit: Edit
         destroy: Destroy
         confirm_destroy: ¿Are you sure?
+        voters: Download voters identifiers
       messages:
         census_limit: Tu usuario no tiene la antigüedad requerida para participar en esta votación.
         finished: Ha llegado la fecha límite para votar. La votación está cerrada.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -42,6 +42,7 @@ es:
         edit: Editar
         destroy: Borrar
         confirm_destroy: ¿Estás seguro?
+        voters: Descargar identificadores de votantes
       messages:
         census_limit: Tu usuario no tiene la antigüedad requerida para participar en esta votación.
         finished: Ha llegado la fecha límite para votar. La votación está cerrada.

--- a/lib/decidim/votings/admin_engine.rb
+++ b/lib/decidim/votings/admin_engine.rb
@@ -11,7 +11,9 @@ module Decidim
       paths["db/migrate"] = nil
 
       routes do
-        resources :votings
+        resources :votings do
+          resources :votes, only: [:index], constraints: { format: "txt" }
+        end
 
         root to: "votings#index"
       end

--- a/lib/decidim/votings/test/factories.rb
+++ b/lib/decidim/votings/test/factories.rb
@@ -54,6 +54,7 @@ FactoryBot.define do
   factory :simulated_vote, class: Decidim::Votings::SimulatedVote do
     voting { create(:voting) }
     user { create(:user) }
+    simulation_code { 666 }
     status { "pending" }
   end
 end

--- a/spec/controllers/decidim/votings/admin/votes_controller_spec.rb
+++ b/spec/controllers/decidim/votings/admin/votes_controller_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Votings
+    module Admin
+      describe VotesController, type: :controller do
+        routes { Decidim::Votings::AdminEngine.routes }
+
+        let(:user) { create(:user, :confirmed, :admin, organization: feature.organization) }
+
+        let(:feature) { create :voting_feature, :participatory_process }
+
+        let(:election_id) { "6666" }
+
+        let(:vote_voter_id) { "6036dfb5fb227d22f8728317d572d972f67304c188281cd72319a581502a7ef2" }
+        let(:simulated_voter_id) { "7036dfb5fb227d22f8728317d572d972f67304c188281cd72319a581502a7ef2" }
+        let(:other_voter_id) { "8036dfb5fb227d22f8728317d572d972f67304c188281cd72319a581502a7ef2" }
+
+        let(:params) do
+          {
+            feature_id: feature.id,
+            participatory_process_slug: feature.participatory_space.slug,
+            voting_id: voting.id,
+            format: "txt"
+          }
+        end
+
+        before do
+          request.env["decidim.current_organization"] = feature.organization
+          request.env["decidim.current_feature"] = feature
+          sign_in user
+        end
+
+        context "when getting list of voters identifiers" do
+          let!(:vote) { create(:vote, voting: voting, voter_identifier: vote_voter_id, user: user) }
+          let!(:simulated_vote) { create(:simulated_vote, voting: voting, voter_identifier: simulated_voter_id, user: user, simulation_code: 666) }
+          let!(:simulated_vote_other) { create(:simulated_vote, voting: voting, voter_identifier: other_voter_id, user: user, simulation_code: 777) }
+
+          context "when voting is not started" do
+            let(:voting) { create(:voting, :not_started, feature: feature, voting_identifier: election_id, simulation_code: 666) }
+
+            it "shows only voter_id of simulated votes of the same simulation" do
+              get :index, params: params
+              identifiers = assigns(:votes).map(&:voter_identifier)
+              expect(identifiers).to include simulated_vote.voter_identifier
+              expect(identifiers).not_to include simulated_vote_other.voter_identifier
+              expect(identifiers).not_to include vote.voter_identifier
+            end
+          end
+
+          context "when voting has started" do
+            let(:voting) { create(:voting, feature: feature, voting_identifier: election_id, simulation_code: 666) }
+
+            it "shows only voter_id of votes without simulateds" do
+              get :index, params: params
+              identifiers = assigns(:votes).map(&:voter_identifier)
+              expect(identifiers).not_to include simulated_vote.voter_identifier
+              expect(identifiers).not_to include simulated_vote_other.voter_identifier
+              expect(identifiers).to include vote.voter_identifier
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/decidim/votings/vote_confirmation/confirmations_controller_spec.rb
+++ b/spec/controllers/decidim/votings/vote_confirmation/confirmations_controller_spec.rb
@@ -52,7 +52,7 @@ module Decidim
           end
 
           context "when simulated vote exists" do
-            let!(:simulated_vote) { create(:vote, voting: voting, voter_identifier: voter_id, user: user) }
+            let!(:simulated_vote) { create(:simulated_vote, voting: voting, voter_identifier: voter_id, user: user) }
 
             it "confirms the vote" do
               get :confirm, params: { election_id: election_id, voter_id: voter_id }

--- a/spec/decidim_dummy_app/db/schema.rb
+++ b/spec/decidim_dummy_app/db/schema.rb
@@ -165,23 +165,6 @@ ActiveRecord::Schema.define(version: 20171211164844) do
     t.index ["decidim_root_commentable_type", "decidim_root_commentable_id"], name: "decidim_comments_comment_root_commentable"
   end
 
-  create_table "decidim_dummy_resources", force: :cascade do |t|
-    t.string "title"
-    t.text "address"
-    t.float "latitude"
-    t.float "longitude"
-    t.bigint "decidim_feature_id"
-    t.bigint "decidim_author_id"
-    t.bigint "decidim_category_id"
-    t.bigint "decidim_scope_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["decidim_author_id"], name: "index_decidim_dummy_resources_on_decidim_author_id"
-    t.index ["decidim_category_id"], name: "index_decidim_dummy_resources_on_decidim_category_id"
-    t.index ["decidim_feature_id"], name: "index_decidim_dummy_resources_on_decidim_feature_id"
-    t.index ["decidim_scope_id"], name: "index_decidim_dummy_resources_on_decidim_scope_id"
-  end
-
   create_table "decidim_features", id: :serial, force: :cascade do |t|
     t.string "manifest_name"
     t.jsonb "name"
@@ -667,7 +650,7 @@ ActiveRecord::Schema.define(version: 20171211164844) do
     t.string "voter_identifier"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "simulation_code", default: 0, null: false
+    t.integer "simulation_code", null: false
     t.index ["decidim_user_id"], name: "index_decidim_votings_simulated_votes_on_decidim_user_id"
     t.index ["decidim_votings_voting_id", "decidim_user_id", "simulation_code"], name: "idx_simulated_votes_voting_user_code", unique: true
     t.index ["decidim_votings_voting_id"], name: "index_simulated_votes_on_voting"

--- a/spec/models/decidim/votings/abilities/current_user_ability_spec.rb
+++ b/spec/models/decidim/votings/abilities/current_user_ability_spec.rb
@@ -27,6 +27,7 @@ describe Decidim::Votings::Abilities::CurrentUserAbility do
 
       it "allows to vote" do
         expect(feature_settings).to receive(:remote_authorization_url)
+          .at_most(:twice)
           .and_return(remote_authorization_url)
         expect(subject).to be_able_to(:vote, voting)
       end
@@ -38,6 +39,7 @@ describe Decidim::Votings::Abilities::CurrentUserAbility do
 
       it "does not allow to vote" do
         expect(feature_settings).to receive(:remote_authorization_url)
+          .at_most(:twice)
           .and_return(remote_authorization_url)
         expect(subject).not_to be_able_to(:vote, voting)
       end


### PR DESCRIPTION
It downloads voters ids online. We can use sidekiq or something similar to do the same in background. I don't know if decidim already uses some job scheduler.
closes https://github.com/podemos-info/decidim-module-votings/issues/10