### PR TITLE
Scope overrides for votings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 ruby RUBY_VERSION
 
-gem "decidim", git: "https://github.com/decidim/decidim", branch: "master"
+gem "decidim", git: "https://github.com/decidim/decidim", branch: "scopes_missing_features"
 gem "decidim-votings", path: "."
 
 gem "puma", "~> 3.0"
@@ -13,7 +13,7 @@ gem "uglifier", "~> 4.1"
 group :development, :test do
   gem "byebug", "~> 10.0", platform: :mri
 
-  gem "decidim-dev", git: "https://github.com/decidim/decidim", branch: "master"
+  gem "decidim-dev", git: "https://github.com/decidim/decidim", branch: "scopes_missing_features"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/decidim/decidim
-  revision: 27ed420db77a8bf2b742f1bc7e67f1c8131dcfc3
-  branch: master
+  revision: c804c7c550228a6a8aa29ab9e28329f270514f2b
+  branch: scopes_missing_features
   specs:
     decidim (0.10.0.pre)
       decidim-accountability (= 0.10.0.pre)

--- a/app/assets/javascripts/decidim/votings/admin/votings.js.es6
+++ b/app/assets/javascripts/decidim/votings/admin/votings.js.es6
@@ -19,15 +19,15 @@ $(() => {
     const createElectoralDistrictId = () => {
       electoralDistrictCounter += 1;
 
-      return `electoral-district-${new Date().getTime()}-${electoralDistrictCounter}`;
+      return `electoral-district-fields-${new Date().getTime()}-${electoralDistrictCounter}`;
     }
 
     $("form").on("click", ".add-electoral-district", function (event) {
       const id = createElectoralDistrictId();
-      const content = $(this).data("form-content").replace("voting[electoral_districts]_scope", id);
+      const content = $(this).data("form-content").replace("electoral-district-fields-id", id);
 
       $(this).before(content);
-      exports.theDataPicker.activate(`#${id}`);
+      exports.theDataPicker.activate(`#${id} .data-picker`);
 
       event.preventDefault();
     });
@@ -35,10 +35,10 @@ $(() => {
     $("form").on("click", ".remove-electoral-district", function (event) {
       const $removedFields = $(this).parents(".electoral-district-fields");
       const $deletedFields = $removedFields.find("input");
-      const idInput = $deletedFields.filter((idx, input) => input.name.match(/id/));
+      const idInput = $deletedFields.filter((idx, input) => input.name.match(/\[id\]/));
 
       if (idInput.length > 0) {
-        const deleteInput = $deletedFields.filter((idx, input) => input.name.match(/delete/));
+        const deleteInput = $deletedFields.filter((idx, input) => input.name.match(/\[deleted\]/));
 
         if (deleteInput.length > 0) {
           $(deleteInput[0]).val(true);

--- a/app/assets/javascripts/decidim/votings/admin/votings.js.es6
+++ b/app/assets/javascripts/decidim/votings/admin/votings.js.es6
@@ -1,3 +1,5 @@
+/* eslint-disable no-invalid-this */
+
 $(() => {
   ((exports) => {
     const $votingScopesEnabled = $('#voting_scopes_enabled');
@@ -11,5 +13,44 @@ $(() => {
 
       exports.theDataPicker.enabled($votingDecidimScopeId, $votingScopesEnabled.prop('checked'));
     }
+
+    let electoralDistrictCounter = 0;
+
+    const createElectoralDistrictId = () => {
+      electoralDistrictCounter += 1;
+
+      return `electoral-district-${new Date().getTime()}-${electoralDistrictCounter}`;
+    }
+
+    $("form").on("click", ".add-electoral-district", function (event) {
+      const id = createElectoralDistrictId();
+      const content = $(this).data("form-content").replace("voting[electoral_districts]_scope", id);
+
+      $(this).before(content);
+      exports.theDataPicker.activate(`#${id}`);
+
+      event.preventDefault();
+    });
+
+    $("form").on("click", ".remove-electoral-district", function (event) {
+      const $removedFields = $(this).parents(".electoral-district-fields");
+      const $deletedFields = $removedFields.find("input");
+      const idInput = $deletedFields.filter((idx, input) => input.name.match(/id/));
+
+      if (idInput.length > 0) {
+        const deleteInput = $deletedFields.filter((idx, input) => input.name.match(/delete/));
+
+        if (deleteInput.length > 0) {
+          $(deleteInput[0]).val(true);
+        }
+
+        $removedFields.addClass('hidden');
+        $removedFields.hide();
+      } else {
+        $removedFields.remove();
+      }
+
+      event.preventDefault();
+    });
   })(window);
 });

--- a/app/assets/stylesheets/decidim/votings/_voting_list.scss
+++ b/app/assets/stylesheets/decidim/votings/_voting_list.scss
@@ -1,4 +1,29 @@
-.voting-icon{
-  float: left;
-  margin-right: 5px;
+.electoral-district-fields{
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+
+  .inline-field{
+    margin-bottom: 0;
+    margin-right: 10px;
+    height: 40px;
+
+    .data-picker,
+    input[type=text],
+    .action-icon *{
+      height: 100%;
+    }
+
+    &:last-child{
+      margin-right: 0;
+    }
+  }
+
+  .inline-field--main{
+    flex: 1 0 400px;
+  }
+
+  .inline-field--action{
+    flex: 0;
+  }
 }

--- a/app/commands/decidim/votings/admin/update_voting.rb
+++ b/app/commands/decidim/votings/admin/update_voting.rb
@@ -21,7 +21,11 @@ module Decidim
         def call
           return broadcast(:invalid) if form.invalid?
 
-          update_voting
+          transaction do
+            update_voting
+            update_electoral_districts
+          end
+
           broadcast(:ok)
         end
 
@@ -50,6 +54,26 @@ module Decidim
 
         def append_shared_key(attrs)
           attrs[:shared_key] = form.shared_key if form.shared_key.present? && form.change_shared_key && voting.can_change_shared_key?
+        end
+
+        def update_electoral_districts
+          form.electoral_districts.each do |electoral_district_form|
+            electoral_districts = voting.electoral_districts
+
+            if electoral_district_form.for_creation?
+              electoral_districts.create!(
+                scope: electoral_district_form.scope,
+                voting_identifier: electoral_district_form.voting_identifier
+              )
+            elsif electoral_district_form.for_update?
+              electoral_districts.find(electoral_district_form.id).update!(
+                scope: electoral_district_form.scope,
+                voting_identifier: electoral_district_form.voting_identifier
+              )
+            else
+              electoral_districts.delete(electoral_district_form.id)
+            end
+          end
         end
       end
     end

--- a/app/controllers/decidim/votings/admin/votings_controller.rb
+++ b/app/controllers/decidim/votings/admin/votings_controller.rb
@@ -6,6 +6,7 @@ module Decidim
       class VotingsController < Admin::ApplicationController
         helper Decidim::Votings::Admin::VotingsHelper
         helper Decidim::Votings::VotingsHelper
+        helper Decidim::DecidimFormHelper
 
         def new
           @form = voting_form.instance

--- a/app/forms/decidim/votings/admin/electoral_district_form.rb
+++ b/app/forms/decidim/votings/admin/electoral_district_form.rb
@@ -16,6 +16,18 @@ module Decidim
         def scope
           @scope ||= Decidim::Scope.find_by(id: decidim_scope_id)
         end
+
+        def for_creation?
+          id.nil?
+        end
+
+        def for_update?
+          !id.nil? && !delete
+        end
+
+        def for_removal?
+          !id.nil? && delete
+        end
       end
     end
   end

--- a/app/forms/decidim/votings/admin/electoral_district_form.rb
+++ b/app/forms/decidim/votings/admin/electoral_district_form.rb
@@ -8,7 +8,8 @@ module Decidim
       class ElectoralDistrictForm < Decidim::Form
         attribute :decidim_scope_id, Integer
         attribute :voting_identifier, String
-        attribute :delete, Boolean, default: false
+        attribute :deleted, Boolean, default: false
+        attribute :id, String
 
         validates :scope, presence: true
         validates :voting_identifier, presence: true
@@ -18,15 +19,15 @@ module Decidim
         end
 
         def for_creation?
-          id.nil?
+          id.blank?
         end
 
         def for_update?
-          !id.nil? && !delete
+          id.present? && !deleted
         end
 
         def for_removal?
-          !id.nil? && delete
+          id.present? && deleted
         end
       end
     end

--- a/app/forms/decidim/votings/admin/electoral_district_form.rb
+++ b/app/forms/decidim/votings/admin/electoral_district_form.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    module Admin
+      # Encapsulates a form to hold the information for a voting that can be
+      # overriden on an scope basis
+      class ElectoralDistrictForm < Decidim::Form
+        attribute :decidim_scope_id, Integer
+        attribute :voting_identifier, String
+        attribute :delete, Boolean, default: false
+
+        validates :scope, presence: true
+        validates :voting_identifier, presence: true
+
+        def scope
+          @scope ||= Decidim::Scope.find_by(id: decidim_scope_id)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/decidim/votings/admin/voting_form.rb
+++ b/app/forms/decidim/votings/admin/voting_form.rb
@@ -26,6 +26,7 @@ module Decidim
         attribute :simulation_code, Integer
         attribute :can_change_shared_key, Boolean
         attribute :change_shared_key, Boolean
+        attribute :electoral_districts, Array[ElectoralDistrictForm]
 
         validates :title, translatable_presence: true
         validates :description, translatable_presence: true

--- a/app/forms/decidim/votings/admin/voting_form.rb
+++ b/app/forms/decidim/votings/admin/voting_form.rb
@@ -45,6 +45,9 @@ module Decidim
           self.scopes_enabled = voting.scope.present?
           self.can_change_shared_key = voting.can_change_shared_key?
           self.change_shared_key = false
+          self.electoral_districts = voting.electoral_districts.map do |electoral_district|
+            ElectoralDistrictForm.from_model(electoral_district)
+          end
         end
 
         def space_scope

--- a/app/helpers/decidim/votings/admin/votings_helper.rb
+++ b/app/helpers/decidim/votings/admin/votings_helper.rb
@@ -22,10 +22,8 @@ module Decidim
           Decidim::Votings::Voting.statuses.keys.map { |status| [I18n.t(status, scope: "activemodel.attributes.voting.statuses"), status] }
         end
 
-        def link_to_add_electoral_district(label, form)
-          form_content = form.fields_for :electoral_districts, ElectoralDistrictForm.new do |builder|
-            render "decidim/votings/admin/votings/electoral_district_fields", builder: builder
-          end
+        def link_to_add_electoral_district(label)
+          form_content = render "decidim/votings/admin/votings/electoral_district_fields", electoral_district: ElectoralDistrictForm.new
 
           link_to label, "#", class: "add-electoral-district", data: { "form-content" => form_content.html_safe }
         end

--- a/app/helpers/decidim/votings/admin/votings_helper.rb
+++ b/app/helpers/decidim/votings/admin/votings_helper.rb
@@ -21,6 +21,14 @@ module Decidim
         def voting_statuses_options
           Decidim::Votings::Voting.statuses.keys.map { |status| [I18n.t(status, scope: "activemodel.attributes.voting.statuses"), status] }
         end
+
+        def link_to_add_electoral_district(label, form)
+          form_content = form.fields_for :electoral_districts, ElectoralDistrictForm.new do |builder|
+            render "decidim/votings/admin/votings/electoral_district_fields", builder: builder
+          end
+
+          link_to label, "#", class: "add-electoral-district", data: { "form-content" => form_content.html_safe }
+        end
       end
     end
   end

--- a/app/models/decidim/votings/electoral_district.rb
+++ b/app/models/decidim/votings/electoral_district.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    class ElectoralDistrict < Decidim::Votings::ApplicationRecord
+      belongs_to :voting, foreign_key: :decidim_votings_voting_id
+      belongs_to :scope, foreign_key: :decidim_scope_id
+    end
+  end
+end

--- a/app/models/decidim/votings/voting.rb
+++ b/app/models/decidim/votings/voting.rb
@@ -21,6 +21,8 @@ module Decidim
       has_many :votes, foreign_key: "decidim_votings_voting_id", inverse_of: :voting, dependent: :destroy
       has_many :simulated_votes, foreign_key: "decidim_votings_voting_id", inverse_of: :voting, dependent: :destroy
 
+      has_many :electoral_districts, foreign_key: "decidim_votings_voting_id", inverse_of: :voting, dependent: :destroy
+
       scope :for_feature, ->(feature) { where(feature: feature) }
       scope :active, -> { where("? BETWEEN start_date AND end_date", DateTime.current) }
       scope :order_by_importance, -> { order(:importance) }

--- a/app/views/decidim/votings/admin/votings/_electoral_district_fields.html.erb
+++ b/app/views/decidim/votings/admin/votings/_electoral_district_fields.html.erb
@@ -1,12 +1,15 @@
-<div class="card-section electoral-district-fields">
+<div id="electoral-district-fields-<%= electoral_district.id || "id" %>" class="card-section electoral-district-fields">
   <span class="inline-field inline-field--main">
-    <%= scopes_picker_field builder, :scope, options: { label: false } %>
+    <%= scopes_picker_tag "voting[electoral_districts][][decidim_scope_id]", electoral_district.decidim_scope_id, options: { label: false, field: t(".a_scope") } %>
   </span>
 
   <span class="inline-field">
-    <%= builder.text_field :voting_identifier, label: false, placeholder: "Voting identifier" %>
-    <%= builder.hidden_field :id, disabled: builder.object.persisted? %>
-    <%= builder.hidden_field :delete, disabled: builder.object.persisted? %>
+    <%= text_field_tag "voting[electoral_districts][][voting_identifier]", electoral_district.voting_identifier, label: false, placeholder: "Voting identifier" %>
+
+    <% unless electoral_district.for_creation? %>
+      <%= hidden_field_tag "voting[electoral_districts][][id]", electoral_district.id %>
+      <%= hidden_field_tag "voting[electoral_districts][][deleted]", electoral_district.deleted %>
+    <% end %>
   </span>
 
   <span class="inline-field inline-field--action">

--- a/app/views/decidim/votings/admin/votings/_electoral_district_fields.html.erb
+++ b/app/views/decidim/votings/admin/votings/_electoral_district_fields.html.erb
@@ -1,0 +1,15 @@
+<div class="card-section electoral-district-fields">
+  <span class="inline-field inline-field--main">
+    <%= scopes_picker_field builder, :scope, options: { label: false } %>
+  </span>
+
+  <span class="inline-field">
+    <%= builder.text_field :voting_identifier, label: false, placeholder: "Voting identifier" %>
+    <%= builder.hidden_field :id, disabled: builder.object.persisted? %>
+    <%= builder.hidden_field :delete, disabled: builder.object.persisted? %>
+  </span>
+
+  <span class="inline-field inline-field--action">
+    <%= icon_link_to "circle-x", "#", t(".remove"), class: "action-icon--remove remove-electoral-district" %>
+  </span>
+</div>

--- a/app/views/decidim/votings/admin/votings/_form.html.erb
+++ b/app/views/decidim/votings/admin/votings/_form.html.erb
@@ -86,9 +86,22 @@
         <% end %>
       <% end %>
     </div>
-
-
   </div>
 </div>
 
+<% if current_participatory_space.has_subscopes? %>
+  <div class="card electoral-districts">
+    <div class="card-divider">
+      <h2 class="card-title">
+        <%= t(".electoral_districts") %>
+      </h2>
+    </div>
+
+    <div class="card-section">
+      <%= link_to_add_electoral_district t(".add_electoral_district"), form %>
+    </div>
+  </div>
+<% end %>
+
 <%= javascript_include_tag 'decidim/votings/admin/votings' %>
+<%= stylesheet_link_tag 'decidim/votings/votings' %>

--- a/app/views/decidim/votings/admin/votings/_form.html.erb
+++ b/app/views/decidim/votings/admin/votings/_form.html.erb
@@ -98,7 +98,11 @@
     </div>
 
     <div class="card-section">
-      <%= link_to_add_electoral_district t(".add_electoral_district"), form %>
+      <% form.object.electoral_districts.each do |electoral_district| %>
+        <%= render "electoral_district_fields", electoral_district: electoral_district %>
+      <% end %>
+
+      <%= link_to_add_electoral_district t(".add_electoral_district") %>
     </div>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,5 @@
+---
+
 en:
   activemodel:
     errors:
@@ -67,8 +69,13 @@ en:
               one: Votación
               other: Votaciones
         votings:
+          electoral_district_fields:
+            remove: Remove
+            title: Electoral district information
           form:
+            add_electoral_district: Add electoral district information
             start_date_help: Start date
+            electoral_districts: Electoral districts
             end_date_help: End date
             census_date_limit_help: Census closing date.
           index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,7 @@ en:
           electoral_district_fields:
             remove: Remove
             title: Electoral district information
+            a_scope: a scope
           form:
             add_electoral_district: Add electoral district information
             start_date_help: Start date

--- a/db/migrate/20180301123833_create_decidim_votings_electoral_districts.rb
+++ b/db/migrate/20180301123833_create_decidim_votings_electoral_districts.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateDecidimVotingsElectoralDistricts < ActiveRecord::Migration[5.1]
+  def change
+    create_table :decidim_votings_electoral_districts do |t|
+      t.references :decidim_scope, foreign_key: true
+      t.references :decidim_votings_voting, foreign_key: true, index: { name: :decidim_votings_electoral_distrings_on_voting_id }
+      t.string :voting_identifier
+    end
+  end
+end

--- a/lib/decidim/votings/test/factories.rb
+++ b/lib/decidim/votings/test/factories.rb
@@ -41,6 +41,13 @@ FactoryBot.define do
     end
   end
 
+  factory :electoral_district, class: "Decidim::Votings::ElectoralDistrict" do
+    scope
+    voting
+
+    voting_identifier 999
+  end
+
   factory :vote, class: "Decidim::Votings::Vote" do
     voting { create(:voting) }
     user { create(:user) }

--- a/spec/commands/decidim/votings/admin/create_voting_spec.rb
+++ b/spec/commands/decidim/votings/admin/create_voting_spec.rb
@@ -33,6 +33,19 @@ module Decidim
         let(:voting_domain_name) { "test.org" }
         let(:voting_identifier) { "identifier" }
         let(:shared_key) { "SHARED_KEY" }
+
+        let(:child_scope) { create(:scope, parent: scope) }
+
+        let(:electoral_districts) do
+          [
+            double(
+              ElectoralDistrictForm,
+              voting_identifier: "NEW",
+              scope: child_scope
+            )
+          ]
+        end
+
         let(:form) do
           double(
             invalid?: invalid,
@@ -50,7 +63,8 @@ module Decidim
             voting_domain_name: voting_domain_name,
             current_feature: current_feature,
             voting_identifier: voting_identifier,
-            shared_key: shared_key
+            shared_key: shared_key,
+            electoral_districts: electoral_districts
           )
         end
 
@@ -75,6 +89,14 @@ module Decidim
             subject.call
 
             expect(voting.feature).to eq current_feature
+          end
+
+          it "sets the electoral districts" do
+            subject.call
+
+            expect(voting.electoral_districts.count).to eq(1)
+            expect(voting.electoral_districts.first.voting_identifier).to eq("NEW")
+            expect(voting.electoral_districts.first.scope).to eq(child_scope)
           end
 
           it "sets all attributes received from the form" do

--- a/spec/forms/decidim/votings/admin/electoral_district_form_spec.rb
+++ b/spec/forms/decidim/votings/admin/electoral_district_form_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Votings
+    module Admin
+      describe ElectoralDistrictForm do
+        subject { described_class.from_params(attributes) }
+
+        let(:organization) { create(:organization) }
+        let(:scope) { create(:scope, organization: organization) }
+        let(:scope_id) { scope.id }
+
+        let(:voting_identifier) { "identifier" }
+
+        let(:attributes) do
+          {
+            decidim_scope_id: scope_id,
+            voting_identifier: voting_identifier
+          }
+        end
+
+        it { is_expected.to be_valid }
+
+        context "when the scope does not exist" do
+          let(:scope_id) { scope.id + 10 }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context "when the scope is missing" do
+          let(:scope_id) { nil }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context "when voting identifier is nil" do
+          let(:voting_identifier) { nil }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context "when voting identifier is blank" do
+          let(:voting_identifier) { "" }
+
+          it { is_expected.not_to be_valid }
+        end
+      end
+    end
+  end
+end

--- a/spec/shared/manage_votings_examples.rb
+++ b/spec/shared/manage_votings_examples.rb
@@ -14,6 +14,14 @@ shared_examples "manage votings" do
       expect(page).to have_no_selector("#voting_decidim_scope_id", class: "disabled")
     end
 
+    it "allows adding electoral district information" do
+      click_link "Add electoral district information"
+      expect(page).to have_selector(".electoral-district-fields", count: 1)
+
+      page.find(".action-icon--remove").click
+      expect(page).to have_selector(".electoral-district-fields", count: 0)
+    end
+
     context "with invalid data" do
       before do
         within ".new_voting" do


### PR DESCRIPTION
This adds the concept of "electoral districts", namely, the ability to configure certain aspects of a voting on a per scope basis. For now, only the "voting identifier" is overridable this way.

It's implemented as a separate model that defines a many to many relationship between scopes and votings. It's rendered as a nested form together with the voting form.

There's some data validation issues/doubts with these nested forms that I'll be opening as issues and handling in separate PRs.

Also, there's the follow up work of using this information in the frontend to link the user to the voting identifier her scope belongs to.

![demo](https://user-images.githubusercontent.com/2887858/36873381-12611d40-1d87-11e8-90ef-d3afa08db5d5.gif)

Sits on top of #35 for convenience and requires some changes in decidim core (this PR currently links to the appropriate branch implementing those changes). 