### PR TITLE
Disable scopes_enabled checkbox

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/decidim/decidim
-  revision: c804c7c550228a6a8aa29ab9e28329f270514f2b
+  revision: cb70aded58b9215a495f0509e49daef930eec478
   branch: scopes_missing_features
   specs:
     decidim (0.10.0.pre)

--- a/app/assets/javascripts/decidim/votings/admin/votings.js.es6
+++ b/app/assets/javascripts/decidim/votings/admin/votings.js.es6
@@ -2,18 +2,6 @@
 
 $(() => {
   ((exports) => {
-    const $votingScopesEnabled = $('#voting_scopes_enabled');
-    const $votingDecidimScopeId = $("#voting_decidim_scope_id");
-
-    if ($('.edit_voting, .new_voting').length > 0) {
-      $votingScopesEnabled.on('change', function (event) {
-        const checked = event.target.checked;
-        exports.theDataPicker.enabled($votingDecidimScopeId, checked);
-      })
-
-      exports.theDataPicker.enabled($votingDecidimScopeId, $votingScopesEnabled.prop('checked'));
-    }
-
     let electoralDistrictCounter = 0;
 
     const createElectoralDistrictId = () => {

--- a/app/forms/decidim/votings/admin/voting_form.rb
+++ b/app/forms/decidim/votings/admin/voting_form.rb
@@ -15,7 +15,6 @@ module Decidim
         attribute :start_date, Decidim::Attributes::TimeWithZone
         attribute :end_date, Decidim::Attributes::TimeWithZone
         attribute :image, String
-        attribute :scopes_enabled, Boolean
         attribute :decidim_scope_id, Integer
         attribute :importance, Integer
         attribute :census_date_limit, Decidim::Attributes::TimeWithZone
@@ -42,7 +41,6 @@ module Decidim
         validate :voting_range_in_process_bounds
 
         def map_model(voting)
-          self.scopes_enabled = voting.scope.present?
           self.can_change_shared_key = voting.can_change_shared_key?
           self.change_shared_key = false
           self.electoral_districts = voting.electoral_districts.map do |electoral_district|
@@ -56,7 +54,7 @@ module Decidim
 
         def scope
           return unless current_feature
-          return space_scope if !scopes_enabled || decidim_scope_id.blank?
+          return space_scope if decidim_scope_id.blank?
           @scope ||= (space_scope.try(:descendants) || current_feature.scopes).where(id: decidim_scope_id).first
         end
 

--- a/app/views/decidim/votings/admin/votings/_form.html.erb
+++ b/app/views/decidim/votings/admin/votings/_form.html.erb
@@ -34,10 +34,6 @@
 
     <% if current_participatory_space.has_subscopes? %>
       <div class="row">
-        <div class="columns xlarge-4">
-          <%= form.check_box :scopes_enabled %>
-        </div>
-
         <div class="columns xlarge-8">
           <%= scopes_picker_field form, :decidim_scope_id %>
         </div>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -11,7 +11,6 @@ es:
         start_date: Data d'inici
         end_date: Data de fi
         image: Imatge
-        scopes_enabled: Àmbit habilitat
         decidim_scope: Àmbit
         decidim_scope_id: Ámbit
         status: Estat

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,7 +13,6 @@ en:
         start_date: Start date
         end_date: End date
         image: Image
-        scopes_enabled: Scopes enabled
         decidim_scope: Scope
         decidim_scope_id: Scope
         status: Status

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -11,7 +11,6 @@ es:
         start_date: Fecha de inicio
         end_date: Fecha de fin
         image: Imagen
-        scopes_enabled: Ámbitos habilitados
         decidim_scope: Ámbito de participación
         decidim_scope_id: Ámbito de participación
         status: Estado

--- a/spec/commands/decidim/votings/admin/create_voting_spec.rb
+++ b/spec/commands/decidim/votings/admin/create_voting_spec.rb
@@ -54,7 +54,6 @@ module Decidim
             image: image,
             start_date: start_date,
             end_date: end_date,
-            scopes_enabled: true,
             scope: scope,
             importance: importance,
             census_date_limit: census_date_limit,

--- a/spec/commands/decidim/votings/admin/update_voting_spec.rb
+++ b/spec/commands/decidim/votings/admin/update_voting_spec.rb
@@ -48,7 +48,6 @@ module Decidim
             image: image,
             start_date: start_date,
             end_date: end_date,
-            scopes_enabled: true,
             scope: scope,
             importance: importance,
             census_date_limit: census_date_limit,

--- a/spec/forms/decidim/votings/admin/voting_form_spec.rb
+++ b/spec/forms/decidim/votings/admin/voting_form_spec.rb
@@ -48,7 +48,6 @@ module Decidim
             image: image,
             start_date: start_date,
             end_date: end_date,
-            scopes_enabled: true,
             decidim_scope_id: scope_id,
             importance: importance,
             census_date_limit: census_date_limit,

--- a/spec/shared/manage_votings_examples.rb
+++ b/spec/shared/manage_votings_examples.rb
@@ -6,14 +6,6 @@ shared_examples "manage votings" do
       click_link "New"
     end
 
-    it "properly toggles the scopes checkbox" do
-      expect(page).to have_selector("#voting_decidim_scope_id", class: "disabled")
-
-      check "Scopes enabled"
-
-      expect(page).to have_no_selector("#voting_decidim_scope_id", class: "disabled")
-    end
-
     it "allows adding electoral district information" do
       fill_in_voting_form(
         "en" => "My voting",


### PR DESCRIPTION
This PR removes the `scopes_enabled` checkbox from votings as discussed in #38.