### PR TITLE
Remove unexpected participatory processes dependency

### DIFF
--- a/app/views/layouts/decidim/booth.html.erb
+++ b/app/views/layouts/decidim/booth.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(translated_attribute(current_feature.name)) %>
-<% add_decidim_page_title(translated_attribute(current_participatory_process.title)) %>
+<% add_decidim_page_title(translated_attribute(current_participatory_space.title)) %>
 <% add_decidim_meta_tags(
-  image_url: current_participatory_process.banner_image.url,
-  description: translated_attribute(current_participatory_process.short_description),
+  image_url: current_participatory_space.banner_image.url,
+  description: translated_attribute(current_participatory_space.short_description),
 ) %>
 
 <%= render "layouts/decidim/application" do %>

--- a/app/views/layouts/decidim/booth.html.erb
+++ b/app/views/layouts/decidim/booth.html.erb
@@ -1,4 +1,4 @@
-<% add_decidim_page_title(translated_attribute(current_feature.name)) if try(:current_feature) %>
+<% add_decidim_page_title(translated_attribute(current_feature.name)) %>
 <% add_decidim_page_title(translated_attribute(current_participatory_process.title)) %>
 <% add_decidim_meta_tags(
   image_url: current_participatory_process.banner_image.url,

--- a/app/views/layouts/decidim/booth.html.erb
+++ b/app/views/layouts/decidim/booth.html.erb
@@ -8,5 +8,3 @@
 <%= render "layouts/decidim/application" do %>
     <%= yield %>
 <% end %>
-
-<% provide :meta_image_url, current_participatory_process.banner_image.url %>


### PR DESCRIPTION
I was getting a crash when voting on assembly votings.

I guess we could test this by explicitly testing against each participatory space, but it doesn't seem like the way to go. Ideally we'll have a dummy participatory space in decidim core soon that we can test this against.

I'm also thinking that maybe `current_participatory_process` (or the analogous variable for each participatory space) should not actually be defined, so that components are forced to use `current_participatory_space` and get a crash if they don't. And thus it's easier for them to avoid "participatory space dependent code". Could be a good PR to propose to decidim... 