### PR TITLE
Current scope resolution

### DIFF
--- a/app/controllers/decidim/votings/votes_controller.rb
+++ b/app/controllers/decidim/votings/votes_controller.rb
@@ -6,6 +6,8 @@ module Decidim
     class VotesController < Decidim::Votings::ApplicationController
       helper_method :voting
 
+      helper VotingsHelper
+
       def show
         unless voting.started?
           raise ActionController::RoutingError, "Not Found" if params[:key] != voting.simulation_key

--- a/app/helpers/decidim/votings/votings_helper.rb
+++ b/app/helpers/decidim/votings/votings_helper.rb
@@ -12,6 +12,18 @@ module Decidim
       def voting_status(voting)
         I18n.t(voting.status, scope: "activemodel.attributes.voting.statuses")
       end
+
+      def voting_identifier_for(voting)
+        return voting.voting_identifier if current_scope.blank?
+
+        voting.voting_identifier_for(current_scope)
+      end
+
+      private
+
+      def current_scope
+        Decidim::Votings.scope_resolver.call(current_user)
+      end
     end
   end
 end

--- a/app/views/decidim/votings/votes/_nvotes.html.erb
+++ b/app/views/decidim/votings/votes/_nvotes.html.erb
@@ -12,7 +12,7 @@
 
 <div>
   <div class="nvotes-iframe" style="height:700px;">
-    <a class="agoravoting-voting-booth" href="https://<%= voting.voting_domain_name %>/booth/<%= voting.voting_identifier %>/vote" data-authorization-funcname="getHMAC"><%= t '.loading_cabin' %></a>
+    <a class="agoravoting-voting-booth" href="https://<%= voting.voting_domain_name %>/booth/<%= voting_identifier_for(voting) %>/vote" data-authorization-funcname="getHMAC"><%= t '.loading_cabin' %></a>
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://<%= voting.voting_domain_name %>/admin/avWidgets.min.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","agoravoting-widgets-js");</script>
   </div>
 </div>

--- a/lib/decidim/votings.rb
+++ b/lib/decidim/votings.rb
@@ -15,5 +15,11 @@ module Decidim
     config_accessor :votings_shown_per_page do
       15
     end
+
+    # A proc or a class implementing  a `call` method to return the scope for a
+    # given user
+    config_accessor :scope_resolver do
+      ->(_user) { nil }
+    end
   end
 end


### PR DESCRIPTION
This PR makes actual use of the helper defined in #41 to properly redirect the user to the correct voting cabin according to her scope. By default, the user is assumed to have no scope, and the main voting identifier is used, but component users can define their own "scope resolution" where the user actually has an associated scope.

@leio10 What do you think of this approach? I considered making the method name customizable but it was much harder to test, so I preferred this approach.

Builds on top of #43 and #44 so those should be reviewed first.